### PR TITLE
Build gcc with sanitizers

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
         python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk \
         build-essential bison flex texinfo gperf libtool patchutils bc \
         zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev \
-        libslirp-dev libcrypt-dev && \
+        libslirp-dev && \
     apt-get clean
 COPY gitconfig /root/.gitconfig
 RUN git clone --depth 1 https://github.com/riscv/riscv-gnu-toolchain

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -17,7 +17,6 @@ RUN ./configure --prefix=/opt/riscv --with-arch=rv64g --with-abi=lp64d \
    make -j2 linux
 
 FROM docker.io/ubuntu:24.04 AS spike
-COPY gitconfig /root/.gitconfig
 RUN apt-get update && \
     apt-get install -y build-essential git device-tree-compiler \
         libboost-regex-dev libboost-system-dev libboost-thread-dev && \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,7 +10,7 @@ COPY gitconfig /root/.gitconfig
 RUN git clone --depth 1 https://github.com/riscv/riscv-gnu-toolchain
 WORKDIR /riscv-gnu-toolchain
 COPY gcc14.patch .
-RUN patch -p1 < gcc14.patch
+RUN git apply gcc14.patch
 RUN git submodule update --init --recursive
 RUN ./configure --prefix=/opt/riscv --with-arch=rv64g --with-abi=lp64d \
         --enable-libsanitizer && \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,7 +10,10 @@ COPY gitconfig /root/.gitconfig
 RUN git clone --recursive --shallow-submodules \
    https://github.com/riscv/riscv-gnu-toolchain
 WORKDIR /riscv-gnu-toolchain
-RUN ./configure --prefix=/opt/riscv --with-arch=rv64g --with-abi=lp64d && \
+ENV LDFLAGS="-L/usr/lib -lcrypt"
+ENV CPPFLAGS="-I/usr/include"
+RUN ./configure --prefix=/opt/riscv --with-arch=rv64g --with-abi=lp64d \
+        --enable-libsanitizer && \
    make -j2 linux
 
 FROM docker.io/ubuntu:24.04 AS spike

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,13 +1,11 @@
-FROM docker.io/ubuntu:24.04 AS env
+FROM docker.io/ubuntu:24.04 AS toolchain
 RUN apt-get update && \
-    apt-get install -y build-essential curl git ninja-build \
-        autoconf automake autotools-dev libmpc-dev libmpfr-dev libgmp-dev \
-        gawk build-essential bison flex texinfo gperf libtool patchutils \
-        bc zlib1g-dev libexpat-dev cmake libglib2.0-dev libslirp-dev \
-        python3-pip python3-venv python3-sphinx-rtd-theme && \
+    apt-get install -y autoconf automake autotools-dev curl python3 \
+        python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk \
+        build-essential bison flex texinfo gperf libtool patchutils bc \
+        zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev \
+        libslirp-dev libcrypt-dev && \
     apt-get clean
-
-FROM env AS toolchain
 COPY gitconfig /root/.gitconfig
 RUN git clone --recursive --shallow-submodules \
    https://github.com/riscv/riscv-gnu-toolchain
@@ -15,11 +13,11 @@ WORKDIR /riscv-gnu-toolchain
 RUN ./configure --prefix=/opt/riscv --with-arch=rv64g --with-abi=lp64d && \
    make -j2 linux
 
-FROM env AS spike
+FROM docker.io/ubuntu:24.04 AS spike
 COPY gitconfig /root/.gitconfig
 RUN apt-get update && \
-    apt-get install -y device-tree-compiler libboost-regex-dev \
-        libboost-system-dev libboost-thread-dev && \
+    apt-get install -y build-essential device-tree-compiler \
+        libboost-regex-dev libboost-system-dev libboost-thread-dev && \
     apt-get clean
 RUN git clone \
     https://github.com/riscv-software-src/riscv-isa-sim.git
@@ -28,7 +26,11 @@ RUN ../configure --prefix=/opt/riscv --with-arch=rv64g && \
     make && \
     make install
 
-FROM env AS qemu
+FROM docker.io/ubuntu:24.04 AS qemu
+RUN apt-get update && \
+    apt-get install -y build-essential meson ninja-build \
+        python3-pip python3-venv python3-sphinx-rtd-theme && \
+    apt-get clean
 RUN curl -O https://download.qemu.org/qemu-9.0.0.tar.xz && \
     tar -xf qemu-9.0.0.tar.xz
 WORKDIR /qemu-9.0.0

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -19,7 +19,7 @@ RUN ./configure --prefix=/opt/riscv --with-arch=rv64g --with-abi=lp64d \
 FROM docker.io/ubuntu:24.04 AS spike
 COPY gitconfig /root/.gitconfig
 RUN apt-get update && \
-    apt-get install -y build-essential device-tree-compiler \
+    apt-get install -y build-essential git device-tree-compiler \
         libboost-regex-dev libboost-system-dev libboost-thread-dev && \
     apt-get clean
 RUN git clone \
@@ -31,7 +31,7 @@ RUN ../configure --prefix=/opt/riscv --with-arch=rv64g && \
 
 FROM docker.io/ubuntu:24.04 AS qemu
 RUN apt-get update && \
-    apt-get install -y build-essential meson ninja-build \
+    apt-get install -y build-essential curl libglib2.0-dev meson ninja-build \
         python3-pip python3-venv python3-sphinx-rtd-theme && \
     apt-get clean
 RUN curl -O https://download.qemu.org/qemu-9.0.0.tar.xz && \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,7 +10,7 @@ COPY gitconfig /root/.gitconfig
 RUN git clone --depth 1 https://github.com/riscv/riscv-gnu-toolchain
 WORKDIR /riscv-gnu-toolchain
 COPY gcc14.patch .
-RUN git apply gcc14.patch
+RUN git apply --index gcc14.patch
 RUN git submodule update --init --recursive
 RUN ./configure --prefix=/opt/riscv --with-arch=rv64g --with-abi=lp64d \
         --enable-libsanitizer && \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -7,11 +7,11 @@ RUN apt-get update && \
         libslirp-dev libcrypt-dev && \
     apt-get clean
 COPY gitconfig /root/.gitconfig
-RUN git clone --recursive --shallow-submodules \
-   https://github.com/riscv/riscv-gnu-toolchain
+RUN git clone --depth 1 https://github.com/riscv/riscv-gnu-toolchain
 WORKDIR /riscv-gnu-toolchain
-ENV LDFLAGS="-L/usr/lib -lcrypt"
-ENV CPPFLAGS="-I/usr/include"
+COPY gcc14.patch .
+RUN patch -p1 < gcc14.patch
+RUN git submodule update --init --recursive
 RUN ./configure --prefix=/opt/riscv --with-arch=rv64g --with-abi=lp64d \
         --enable-libsanitizer && \
    make -j2 linux

--- a/container/gcc14.patch
+++ b/container/gcc14.patch
@@ -11,10 +11,3 @@ index 25142daddc6..8ae276efdda 100644
  [submodule "glibc"]
  	path = glibc
  	url = https://sourceware.org/git/glibc.git
-diff --git a/gcc b/gcc
-index c891d8dc23e..cd0059a1976 160000
---- a/gcc
-+++ b/gcc
-@@ -1 +1 @@
--Subproject commit c891d8dc23e1a46ad9f3e757d09e57b500d40044
-+Subproject commit cd0059a1976303638cea95f216de129334fc04d1

--- a/container/gcc14.patch
+++ b/container/gcc14.patch
@@ -1,0 +1,20 @@
+diff --git a/.gitmodules b/.gitmodules
+index 25142daddc6..8ae276efdda 100644
+--- a/.gitmodules
++++ b/.gitmodules
+@@ -5,7 +5,7 @@
+ [submodule "gcc"]
+ 	path = gcc
+ 	url = https://gcc.gnu.org/git/gcc.git
+-	branch = releases/gcc-13
++	branch = releases/gcc-14
+ [submodule "glibc"]
+ 	path = glibc
+ 	url = https://sourceware.org/git/glibc.git
+diff --git a/gcc b/gcc
+index c891d8dc23e..cd0059a1976 160000
+--- a/gcc
++++ b/gcc
+@@ -1 +1 @@
+-Subproject commit c891d8dc23e1a46ad9f3e757d09e57b500d40044
++Subproject commit cd0059a1976303638cea95f216de129334fc04d1

--- a/container/gcc14.patch
+++ b/container/gcc14.patch
@@ -11,3 +11,10 @@ index 25142daddc6..8ae276efdda 100644
  [submodule "glibc"]
  	path = glibc
  	url = https://sourceware.org/git/glibc.git
+diff --git a/gcc b/gcc
+index c891d8dc23e..cd0059a1976 160000
+--- a/gcc
++++ b/gcc
+@@ -1 +1 @@
+-Subproject commit c891d8dc23e1a46ad9f3e757d09e57b500d40044
++Subproject commit cd0059a1976303638cea95f216de129334fc04d1

--- a/container/gitconfig
+++ b/container/gitconfig
@@ -15,3 +15,6 @@
 
 [url "https://git.sr.ht/~sourceware/gcc"]
     insteadOf = https://gcc.gnu.org/git/gcc.git
+
+[url "https://git.linaro.org/toolchain/dejagnu.git"]
+    insteadOf = https://git.savannah.gnu.org/git/dejagnu.git


### PR DESCRIPTION
This was a HUGE debacle, but the short story is that glibc dropped a header that libsanitizer needed, and libsanitizer was updated to not need that header, but the current version of gcc captured in `riscv-gnu-toolchain` doesn't have that fix. So all this works by patching `riscv-gnu-toolchain` to switch to gcc 14. Seems to at least provide a working libsanitizer???