### PR TITLE
Invoke asbin with docker run

### DIFF
--- a/container/mklinks.sh
+++ b/container/mklinks.sh
@@ -14,5 +14,6 @@ done
 # Make a shorter name for qemu.
 ln -s `which qemu-riscv64` /usr/local/bin/qemu
 
-# asbin function for A5
-echo 'asbin() { as "$1" -o tmp.o && objcopy tmp.o -O binary "${1%.*}.bin" && rm tmp.o;}' >> /etc/bash.bashrc
+# Create asbin command
+echo -e '#!/bin/bash\nas "$1" -o tmp.o && objcopy tmp.o -O binary "${1%.*}.bin" && rm tmp.o\n' > /usr/local/bin/asbin
+chmod +x /usr/local/bin/asbin


### PR DESCRIPTION
`asbin` command can now be invoked through `docker run`.
See example usage below:

```
peterengel@dhcp-vl2041-32794 TEST % cat prog.s 
addi ra,ra,1
slli sp,ra,3
peterengel@dhcp-vl2041-32794 TEST % docker run -i -t --rm -v "`pwd`":/root updated-infra asbin prog.s 
peterengel@dhcp-vl2041-32794 TEST % cat prog.bin
???0%
peterengel@dhcp-vl2041-32794 TEST % docker run -i -t --rm -v "`pwd`":/root updated-infra objdump -b binary -m riscv:rv64 -D prog.bin

prog.bin:     file format binary


Disassembly of section .data:

0000000000000000 <.data>:
   0:	00108093          	addi	ra,ra,1
   4:	00309113          	slli	sp,ra,0x3
```
